### PR TITLE
Reflect position of projectile if it is out of bounds

### DIFF
--- a/blocks.lua
+++ b/blocks.lua
@@ -229,11 +229,13 @@ function Grid:considerProjectile(proj)
    
   
     if (proj.position.x < 1) then
+        proj.position.x = 1 + (1 - proj.position.x)
         proj.direction.x = -proj.direction.x;
         Assets.sounds.bounce:play();
     end
   
     if (proj.position.x > self.numCols) then
+        proj.position.x = self.numCols - (proj.position.x - self.numCols)
         proj.direction.x = -proj.direction.x;
         Assets.sounds.bounce:play();
     end


### PR DESCRIPTION
If a projectile went out of bounds by `p` units on the x-axis, that means it would've collided with the wall and actually been to the inside of the wall by `p` units at this point, not outside.